### PR TITLE
No longer reusing http client for thread isolation

### DIFF
--- a/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
+++ b/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
@@ -25,15 +25,16 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
     /// </summary>
     public class HashicorpVaultClient
     {
-        private VaultHttp _vaultHttp { get; set; }
+        private HashicorpVaultCAConfig _caConfig { get; set; }
+        private HashicorpVaultCATemplateConfig _templateConfig { get; set; }
+
         private static readonly ILogger logger = LogHandler.GetClassLogger<HashicorpVaultClient>();
 
         public HashicorpVaultClient(HashicorpVaultCAConfig caConfig, HashicorpVaultCATemplateConfig templateConfig = null)
         {
             logger.MethodEntry();
-
-            SetClientValuesFromConfigs(caConfig, templateConfig);
-
+            _caConfig = caConfig;
+            _templateConfig = templateConfig;
             logger.MethodExit();
         }
 
@@ -101,6 +102,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     Format = "pem_bundle",
                     CSR = csr
                 };
+                var _vaultHttp = ConfigureNewVaultClient();
 
                 logger.LogTrace($"sending request to vault..");
                 logger.LogTrace($"serialized request: {JsonSerializer.Serialize(request)}");
@@ -131,6 +133,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
             try
             {
+                var _vaultHttp = ConfigureNewVaultClient();
                 var response = await _vaultHttp.GetAsync<CertResponse>($"cert/{certSerial}");
                 logger.LogTrace($"successfully received a response for certificate with serial number: {certSerial}");
                 return response;
@@ -151,7 +154,8 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             logger.MethodEntry();
             logger.LogTrace($"making request to revoke cert with serial: {serial}");
             try
-            {                
+            {
+                var _vaultHttp = ConfigureNewVaultClient();
                 var response = await _vaultHttp.PostAsync<RevokeResponse>("revoke", new RevokeRequest(serial));
                 logger.LogTrace($"successfully revoked cert with serial {serial}, revocation time:  {response.RevocationTime}");
                 return response;
@@ -170,6 +174,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             logger.LogTrace($"performing a system health check request to Vault");
             try
             {
+                var _vaultHttp = ConfigureNewVaultClient();
                 var res = await _vaultHttp.HealthCheckAsync();
                 logger.LogTrace($"-- Vault health check response --");
                 logger.LogTrace($"Vault version : {res.VaultVersion}");
@@ -198,6 +203,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             var keys = new List<string>();
             try
             {
+                var _vaultHttp = ConfigureNewVaultClient();
                 var res = await _vaultHttp.GetAsync<WrappedResponse<KeyedList>>("certs/?list=true");
                 return res.Data.Entries;
             }
@@ -215,6 +221,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             var keys = new List<string>();
             try
             {
+                var _vaultHttp = ConfigureNewVaultClient();
                 var res = await _vaultHttp.GetAsync<KeyedList>("certs/revoked");
                 keys = res.Entries;
             }
@@ -233,6 +240,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             var roleNames = new List<string>();
             try
             {
+                var _vaultHttp = ConfigureNewVaultClient();
                 logger.LogTrace("getting the role names as a wrapped keyed-list response..");
                 var response = await _vaultHttp.GetAsync<WrappedResponse<KeyedList>>("roles/?list=true");
                 logger.LogTrace($"received {response.Data?.Entries?.Count} role names (or product IDs)");
@@ -246,14 +254,14 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             finally { logger.MethodExit(); }            
         }
 
-        private void SetClientValuesFromConfigs(HashicorpVaultCAConfig caConfig, HashicorpVaultCATemplateConfig templateConfig)
+        private VaultHttp ConfigureNewVaultClient()
         {
             logger.MethodEntry();
 
-            var hostUrl = caConfig.Host; // host url and authentication details come from the CA config
-            var token = caConfig.Token;
-            var nameSpace = string.IsNullOrEmpty(templateConfig?.Namespace) ? caConfig.Namespace : templateConfig.Namespace; // Namespace comes from templateconfig if available, otherwise defaults to caConfig; can be null
-            var mountPoint = string.IsNullOrEmpty(templateConfig?.MountPoint) ? caConfig.MountPoint : templateConfig.MountPoint; // Mountpoint comes from templateconfig if available, otherwise defaults to caConfig; if null, uses "pki" (Vault Default)
+            var hostUrl = _caConfig.Host; // host url and authentication details come from the CA config
+            var token = _caConfig.Token;
+            var nameSpace = string.IsNullOrEmpty(_templateConfig?.Namespace) ? _caConfig.Namespace : _templateConfig.Namespace; // Namespace comes from templateconfig if available, otherwise defaults to caConfig; can be null
+            var mountPoint = string.IsNullOrEmpty(_templateConfig?.MountPoint) ? _caConfig.MountPoint : _templateConfig.MountPoint; // Mountpoint comes from templateconfig if available, otherwise defaults to caConfig; if null, uses "pki" (Vault Default)
             mountPoint = mountPoint ?? "pki"; // using the vault default PKI secrets engine mount point if not present in config
 
             logger.LogTrace($"set value for Host url: {hostUrl}");
@@ -268,19 +276,9 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             //{
             //    throw new MissingFieldException("Either an authentication token or certificate to use for authentication into Vault must be provided.");
             //}
-
-            _vaultHttp = new VaultHttp(hostUrl, mountPoint, token, nameSpace);
-
             logger.MethodExit();
-        }
 
-        private static string ConvertSerialToTrackingId(string serialNumber)
-        {
-            // vault returns certificate serial formatted thusly: 17:67:16:b0:b9:45:58:c0:3a:29:e3:cb:d6:98:33:7a:a6:3b:66:c1
-            // we cannot use the ':' character as part of our internal tracking id, but Vault requests can work with either ':' or '-'
-            // so we convert from colon-separated pairs to hyphen separated pairs.
-
-            return serialNumber.Replace(":", "-");
+            return new VaultHttp(hostUrl, mountPoint, token, nameSpace);            
         }
     }
 }

--- a/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
+++ b/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
@@ -11,9 +11,11 @@ using Keyfactor.Logging;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Asn1.X509;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
@@ -197,15 +199,28 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// Retreives all serial numbers for issued certificates 
         /// </summary>
         /// <returns>a list of the certificate serial number strings</returns>
-        public async Task<List<string>> GetAllCertSerialNumbers()
+        public async Task GetAllCertSerialNumbers(BlockingCollection<string> serialNumberCollection, CancellationToken token)
         {
+            if (token.IsCancellationRequested) {
+                logger.LogWarning($"cancelation was requested.  Stopping task");
+                serialNumberCollection.CompleteAdding();
+                return;
+            }
             logger.MethodEntry();
-            var keys = new List<string>();
             try
             {
                 var _vaultHttp = ConfigureNewVaultClient();
                 var res = await _vaultHttp.GetAsync<WrappedResponse<KeyedList>>("certs/?list=true");
-                return res.Data.Entries;
+                var serials = res.Data?.Entries;
+                if (serials == null || serials.Count == 0) {
+                    return;
+                }
+                foreach (var serial in serials) {
+                    if (!serialNumberCollection.TryAdd(serial, 50, token)) {
+                        logger.LogWarning($"unable to add serial number {serial} to the collection");
+                    }
+                }
+                serialNumberCollection.CompleteAdding();
             }
             catch (Exception ex)
             {
@@ -257,30 +272,40 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         private VaultHttp ConfigureNewVaultClient()
         {
             logger.MethodEntry();
+            try
+            {
+                var hostUrl = _caConfig.Host; // host url and authentication details come from the CA config
+                logger.LogTrace($"set value for Host url: {hostUrl}");
 
-            var hostUrl = _caConfig.Host; // host url and authentication details come from the CA config
-            logger.LogTrace($"set value for Host url: {hostUrl}");
+                var token = _caConfig.Token;
+                logger.LogTrace($"set value for authentication token: {token ?? "(not defined)"}");
 
-            var token = _caConfig.Token;
-            logger.LogTrace($"set value for authentication token: {token ?? "(not defined)"}");
+                var nameSpace = string.IsNullOrEmpty(_templateConfig?.Namespace) ? _caConfig.Namespace : _templateConfig.Namespace; // Namespace comes from templateconfig if available, otherwise defaults to caConfig; can be null
+                logger.LogTrace($"set value for Namespace: {nameSpace ?? "(not defined)"}");
 
-            var nameSpace = string.IsNullOrEmpty(_templateConfig?.Namespace) ? _caConfig.Namespace : _templateConfig.Namespace; // Namespace comes from templateconfig if available, otherwise defaults to caConfig; can be null
-            logger.LogTrace($"set value for Namespace: {nameSpace ?? "(not defined)"}");
-
-            var mountPoint = string.IsNullOrEmpty(_templateConfig?.MountPoint) ? _caConfig.MountPoint : _templateConfig.MountPoint; // Mountpoint comes from templateconfig if available, otherwise defaults to caConfig; if null, uses "pki" (Vault Default)
-            mountPoint = mountPoint ?? "pki"; // using the vault default PKI secrets engine mount point if not present in config
-            logger.LogTrace($"set value for Mountpoint: {mountPoint}");
+                var mountPoint = string.IsNullOrEmpty(_templateConfig?.MountPoint) ? _caConfig.MountPoint : _templateConfig.MountPoint; // Mountpoint comes from templateconfig if available, otherwise defaults to caConfig; if null, uses "pki" (Vault Default)
+                mountPoint = mountPoint ?? "pki"; // using the vault default PKI secrets engine mount point if not present in config
+                logger.LogTrace($"set value for Mountpoint: {mountPoint}");
 
 
-            // _certAuthInfo = caConfig?.ClientCertificate;
-            // logger.LogTrace($"set value for Certificate authentication; thumbprint: {_certAuthInfo?.Thumbprint ?? "(missing) - using token authentication"}");
+                // _certAuthInfo = caConfig?.ClientCertificate;
+                // logger.LogTrace($"set value for Certificate authentication; thumbprint: {_certAuthInfo?.Thumbprint ?? "(missing) - using token authentication"}");
 
-            //if (_token == null && _certAuthInfo == null)
-            //{
-            //    throw new MissingFieldException("Either an authentication token or certificate to use for authentication into Vault must be provided.");
-            //}
-           
-            return new VaultHttp(hostUrl, mountPoint, token, nameSpace);            
+                //if (_token == null && _certAuthInfo == null)
+                //{
+                //    throw new MissingFieldException("Either an authentication token or certificate to use for authentication into Vault must be provided.");
+                //}
+
+                return new VaultHttp(hostUrl, mountPoint, token, nameSpace);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError($"error when creating new vault client: {LogHandler.FlattenException(ex)}");
+                throw;
+            }
+            finally {
+                logger.MethodExit();
+            }
         }
     }
 }

--- a/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
+++ b/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
@@ -29,7 +29,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
     {
         private HashicorpVaultCAConfig _caConfig { get; set; }
         private HashicorpVaultCATemplateConfig _templateConfig { get; set; }
-        private readonly ILogger logger;        
+        private readonly ILogger logger;
 
         public HashicorpVaultClient(HashicorpVaultCAConfig caConfig, HashicorpVaultCATemplateConfig templateConfig = null)
         {
@@ -51,8 +51,9 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             string commonName = null, organization = null, orgUnit = null;
 
             logger.LogTrace($"SAN values: ");
-            foreach (var key in san.Keys) {
-                logger.LogTrace($"{key}: {string.Join(",", san[key])}");            
+            foreach (var key in san.Keys)
+            {
+                logger.LogTrace($"{key}: {string.Join(",", san[key])}");
             }
 
             if (san.ContainsKey("dnsname"))
@@ -112,9 +113,9 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 logger.LogTrace($"got a response from vault..");
 
                 if (response.Warnings?.Count > 0) { logger.LogTrace($"the response contained warnings: {string.Join(", ", response.Warnings)}"); }
-                
-                logger.LogTrace($"serialized SignResponse: {JsonSerializer.Serialize(response.Data)}");        
-               
+
+                logger.LogTrace($"serialized SignResponse: {JsonSerializer.Serialize(response.Data)}");
+
                 return response.Data;
             }
             catch (Exception ex)
@@ -181,7 +182,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 logger.LogTrace($"-- Vault health check response --");
                 logger.LogTrace($"Vault version : {res.VaultVersion}");
                 logger.LogTrace($"sealed? : {res.Sealed}");
-                logger.LogTrace($"initialized? : {res.Initialized}");                
+                logger.LogTrace($"initialized? : {res.Initialized}");
                 return true;
             }
             catch (Exception ex)
@@ -199,29 +200,26 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// Retreives all serial numbers for issued certificates 
         /// </summary>
         /// <returns>a list of the certificate serial number strings</returns>
-        public async Task GetAllCertSerialNumbers(BlockingCollection<string> serialNumberCollection, CancellationToken token)
+        public async Task<List<string>> GetAllCertSerialNumbers(CancellationToken token)
         {
-            if (token.IsCancellationRequested) {
-                logger.LogWarning($"cancelation was requested.  Stopping task");
-                serialNumberCollection.CompleteAdding();
-                return;
+            var certSerials = new List<string>();
+            if (token.IsCancellationRequested)
+            {
+                logger.LogWarning($"cancelation was requested; stopping task");
+                return certSerials;
             }
             logger.MethodEntry();
             try
             {
-                var _vaultHttp = ConfigureNewVaultClient();                
+                var _vaultHttp = ConfigureNewVaultClient();
                 var res = await _vaultHttp.GetAsync<WrappedResponse<KeyedList>>("certs/?list=true");
                 var serials = res.Data?.Entries;
-                if (serials == null || serials.Count == 0) {
-                    return;
+                if (serials == null || serials.Count == 0)
+                {
+                    return certSerials;
                 }
                 logger.LogTrace($"got {res.Data?.Entries?.Count} serial numbers from {_caConfig.Host} namespace: {_caConfig.Namespace}, mount-point: {_caConfig.MountPoint}");
-                foreach (var serial in serials) {
-                    if (!serialNumberCollection.TryAdd(serial, 50, token)) {
-                        logger.LogWarning($"unable to add serial number {serial} to the collection");
-                    }
-                }
-                serialNumberCollection.CompleteAdding();
+                return serials;
             }
             catch (Exception ex)
             {
@@ -267,7 +265,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 logger.LogError($"There was a problem retreiving the PKI role names: {LogHandler.FlattenException(ex)}");
                 throw;
             }
-            finally { logger.MethodExit(); }            
+            finally { logger.MethodExit(); }
         }
 
         private VaultHttp ConfigureNewVaultClient()
@@ -304,7 +302,8 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 logger.LogError($"error when creating new vault client: {LogHandler.FlattenException(ex)}");
                 throw;
             }
-            finally {
+            finally
+            {
                 logger.MethodExit();
             }
         }

--- a/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
+++ b/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
@@ -27,11 +27,11 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
     {
         private HashicorpVaultCAConfig _caConfig { get; set; }
         private HashicorpVaultCATemplateConfig _templateConfig { get; set; }
-
-        private static readonly ILogger logger = LogHandler.GetClassLogger<HashicorpVaultClient>();
+        private readonly ILogger logger;        
 
         public HashicorpVaultClient(HashicorpVaultCAConfig caConfig, HashicorpVaultCATemplateConfig templateConfig = null)
         {
+            logger = LogHandler.GetClassLogger<HashicorpVaultClient>();
             logger.MethodEntry();
             _caConfig = caConfig;
             _templateConfig = templateConfig;
@@ -91,7 +91,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     }
                     else
                     {
-                        throw new Exception("No Common Name or DNS SAN provided, unable to enroll");
+                        throw new Exception("no Common Name or DNS SAN provided, unable to enroll");
                     }
                 }
 
@@ -259,15 +259,18 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             logger.MethodEntry();
 
             var hostUrl = _caConfig.Host; // host url and authentication details come from the CA config
+            logger.LogTrace($"set value for Host url: {hostUrl}");
+
             var token = _caConfig.Token;
+            logger.LogTrace($"set value for authentication token: {token ?? "(not defined)"}");
+
             var nameSpace = string.IsNullOrEmpty(_templateConfig?.Namespace) ? _caConfig.Namespace : _templateConfig.Namespace; // Namespace comes from templateconfig if available, otherwise defaults to caConfig; can be null
+            logger.LogTrace($"set value for Namespace: {nameSpace ?? "(not defined)"}");
+
             var mountPoint = string.IsNullOrEmpty(_templateConfig?.MountPoint) ? _caConfig.MountPoint : _templateConfig.MountPoint; // Mountpoint comes from templateconfig if available, otherwise defaults to caConfig; if null, uses "pki" (Vault Default)
             mountPoint = mountPoint ?? "pki"; // using the vault default PKI secrets engine mount point if not present in config
-
-            logger.LogTrace($"set value for Host url: {hostUrl}");
-            logger.LogTrace($"set value for authentication token: {token ?? "(not defined)"}");
-            logger.LogTrace($"set value for Namespace: {nameSpace ?? "(not defined)"}");
             logger.LogTrace($"set value for Mountpoint: {mountPoint}");
+
 
             // _certAuthInfo = caConfig?.ClientCertificate;
             // logger.LogTrace($"set value for Certificate authentication; thumbprint: {_certAuthInfo?.Thumbprint ?? "(missing) - using token authentication"}");
@@ -276,8 +279,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             //{
             //    throw new MissingFieldException("Either an authentication token or certificate to use for authentication into Vault must be provided.");
             //}
-            logger.MethodExit();
-
+           
             return new VaultHttp(hostUrl, mountPoint, token, nameSpace);            
         }
     }

--- a/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
+++ b/hashicorp-vault-cagateway/Client/HashicorpVaultClient.cs
@@ -209,12 +209,13 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             logger.MethodEntry();
             try
             {
-                var _vaultHttp = ConfigureNewVaultClient();
+                var _vaultHttp = ConfigureNewVaultClient();                
                 var res = await _vaultHttp.GetAsync<WrappedResponse<KeyedList>>("certs/?list=true");
                 var serials = res.Data?.Entries;
                 if (serials == null || serials.Count == 0) {
                     return;
                 }
+                logger.LogTrace($"got {res.Data?.Entries?.Count} serial numbers from {_caConfig.Host} namespace: {_caConfig.Namespace}, mount-point: {_caConfig.MountPoint}");
                 foreach (var serial in serials) {
                     if (!serialNumberCollection.TryAdd(serial, 50, token)) {
                         logger.LogWarning($"unable to add serial number {serial} to the collection");
@@ -224,7 +225,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             }
             catch (Exception ex)
             {
-                logger.LogError($"there was an error retreiving the certificate keys: {ex.Message}");
+                logger.LogError($"there was an error retreiving the certificate keys from {_caConfig.Host} using namespace: {_templateConfig.Namespace ?? _caConfig.Namespace} and mount-point: {_caConfig.MountPoint}.  Error: {ex.Message}");
                 throw;
             }
             finally { logger.MethodExit(); }

--- a/hashicorp-vault-cagateway/Client/VaultHttp.cs
+++ b/hashicorp-vault-cagateway/Client/VaultHttp.cs
@@ -92,7 +92,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 if (parameters != null) { request.AddJsonBody(parameters); }
 
                 var response = await restClient.ExecuteGetAsync<T>(request);
-
+                logger.LogTrace($"response headers: {response.Headers}\nresponse content: {response.Content}\nresponse data: {response.Data}");
                 response.ThrowIfError();
 
                 return response.Data;

--- a/hashicorp-vault-cagateway/Client/VaultHttp.cs
+++ b/hashicorp-vault-cagateway/Client/VaultHttp.cs
@@ -27,6 +27,8 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
         private string _mountPoint { get; set; }  // not all requests are the the secrets engine, so can't append this permanently to the base path
         private string _authToken { get; set; }
         private string _nameSpace { get; set; }
+        private JsonSerializerOptions _serializerOptions { get; set; }
+
         private RestClient _restClient;
         protected RestClient restClient
         {
@@ -38,14 +40,13 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 _restClient.AddDefaultHeader("X-Vault-Request", "true");
                 _restClient.AddDefaultHeader("X-Vault-Token", _authToken);
                 if (_nameSpace != null) _restClient.AddDefaultHeader("X-Vault-Namespace", _nameSpace);
-                logger.LogTrace($"configured a new instance of our Vault http client with the provided values:");
+                logger.LogTrace($"configured a new instance of our Vault restsharp client with the configured values:");
                 logger.LogTrace($"vault api path: {_vaultApiPath}");
                 logger.LogTrace($"mount point: {_mountPoint}");
                 logger.LogTrace($"namespace: {_nameSpace}");
                 return _restClient;
             }
-        }
-        private JsonSerializerOptions _serializerOptions { get; set; }
+        }        
 
         private static readonly ILogger logger = LogHandler.GetClassLogger<VaultHttp>();
 
@@ -60,7 +61,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 PropertyNameCaseInsensitive = true,
                 PreferredObjectCreationHandling = JsonObjectCreationHandling.Replace,
             };
-            _vaultApiPath = $"{host.TrimEnd('/')}/v1";
+            _vaultApiPath = $"{host.TrimEnd('/')}/v1"; // api path ends in /v1
             _mountPoint = mountPoint.TrimStart('/').TrimEnd('/');
             _authToken = authToken;
 
@@ -92,7 +93,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 var request = new RestRequest($"{_mountPoint}/{path}", Method.Get);
                 if (parameters != null) { request.AddJsonBody(parameters); }
 
-                var response = await _restClient.ExecuteGetAsync<T>(request);
+                var response = await restClient.ExecuteGetAsync<T>(request);
 
                 response.ThrowIfError();
 
@@ -105,8 +106,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             finally
             {
-                _restClient.Dispose();
-                _restClient = null;
+                DisposeRestClient();
                 logger.MethodExit();
             }
         }
@@ -117,7 +117,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
 
             var resourcePath = $"{_mountPoint}/{path}";
 
-            logger.LogTrace($"preparing to send POST request to {_restClient.Options.BaseUrl}{resourcePath}");
+            logger.LogTrace($"preparing to send POST request to {restClient.Options.BaseUrl}{resourcePath}");
             logger.LogTrace($"will attempt to deserialize the response into a {typeof(T)}");
 
             try
@@ -130,7 +130,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                     request.AddJsonBody(serializedParams);
                 }
 
-                logger.LogTrace($"full url for the request: {_restClient.Options.BaseUrl}/{request.Resource}");
+                logger.LogTrace($"full url for the request: {restClient.Options.BaseUrl}/{request.Resource}");
 
                 var response = await _restClient.ExecutePostAsync<T>(request);
 
@@ -162,8 +162,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             finally
             {
-                _restClient.Dispose();
-                _restClient = null;
+                DisposeRestClient();                
                 logger.MethodExit();
             }
         }
@@ -174,7 +173,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
 
             try
             {
-                return await _restClient.GetAsync<SealStatusResponse>("sys/seal-status");
+                return await restClient.GetAsync<SealStatusResponse>("sys/seal-status");
             }
             catch (Exception ex)
             {
@@ -183,8 +182,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             finally
             {
-                _restClient.Dispose();
-                _restClient = null;
+                DisposeRestClient();
                 logger.MethodExit();
             }
         }
@@ -210,10 +208,14 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             finally
             {
-                _restClient.Dispose();
-                _restClient = null;
+                DisposeRestClient();
                 logger.MethodExit();
             }
+        }
+
+        private void DisposeRestClient() {
+            _restClient.Dispose();
+            _restClient = null;
         }
     }
 }

--- a/hashicorp-vault-cagateway/Client/VaultHttp.cs
+++ b/hashicorp-vault-cagateway/Client/VaultHttp.cs
@@ -23,8 +23,28 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
     /// </summary>
     public class VaultHttp
     {
+        private string _vaultApiPath { get; set; }
         private string _mountPoint { get; set; }  // not all requests are the the secrets engine, so can't append this permanently to the base path
-        private RestClient _restClient { get; set; }
+        private string _authToken { get; set; }
+        private string _nameSpace { get; set; }
+        private RestClient _restClient;
+        protected RestClient restClient
+        {
+            get
+            {
+                if (_restClient != null) { return _restClient; }
+                var restClientOptions = new RestClientOptions(_vaultApiPath) { ThrowOnAnyError = true };
+                _restClient = new RestClient(restClientOptions, configureSerialization: s => s.UseSystemTextJson(_serializerOptions));
+                _restClient.AddDefaultHeader("X-Vault-Request", "true");
+                _restClient.AddDefaultHeader("X-Vault-Token", _authToken);
+                if (_nameSpace != null) _restClient.AddDefaultHeader("X-Vault-Namespace", _nameSpace);
+                logger.LogTrace($"configured a new instance of our Vault http client with the provided values:");
+                logger.LogTrace($"vault api path: {_vaultApiPath}");
+                logger.LogTrace($"mount point: {_mountPoint}");
+                logger.LogTrace($"namespace: {_nameSpace}");
+                return _restClient;
+            }
+        }
         private JsonSerializerOptions _serializerOptions { get; set; }
 
         private static readonly ILogger logger = LogHandler.GetClassLogger<VaultHttp>();
@@ -40,20 +60,16 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 PropertyNameCaseInsensitive = true,
                 PreferredObjectCreationHandling = JsonObjectCreationHandling.Replace,
             };
+            _vaultApiPath = $"{host.TrimEnd('/')}/v1";
+            _mountPoint = mountPoint.TrimStart('/').TrimEnd('/');
+            _authToken = authToken;
 
-            var restClientOptions = new RestClientOptions($"{host.TrimEnd('/')}/v1") { ThrowOnAnyError = true };
-            _restClient = new RestClient(restClientOptions, configureSerialization: s => s.UseSystemTextJson(_serializerOptions));
+            if (!string.IsNullOrEmpty(nameSpace))
+            {
+                _nameSpace = nameSpace;
+            }
 
-            _mountPoint = mountPoint.TrimStart('/').TrimEnd('/'); // remove leading and trailing slashes
-            _restClient.AddDefaultHeader("X-Vault-Request", "true");
-            _restClient.AddDefaultHeader("X-Vault-Token", authToken);
-
-            if (nameSpace != null) _restClient.AddDefaultHeader("X-Vault-Namespace", nameSpace);
-
-            logger.LogTrace($"configured an instance of our restsharp client with the provided values:");
-            logger.LogTrace($"host url: {host}");
-            logger.LogTrace($"mount point: {_mountPoint}");
-            logger.LogTrace($"namespace: {nameSpace}");
+            logger.LogTrace($"configured our httpclient wrapper with the following values:\nbase path: {_vaultApiPath}\nnamespace: {(!string.IsNullOrEmpty(_nameSpace) ? _nameSpace : "(no namespace configured)")}\nmount point: {_mountPoint}\nauth token: {_authToken.Substring(0, 8)}...");
 
             logger.MethodExit();
         }
@@ -89,6 +105,8 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             finally
             {
+                _restClient.Dispose();
+                _restClient = null;
                 logger.MethodExit();
             }
         }
@@ -119,7 +137,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 logger.LogTrace($"request completed. response returned:");
                 logger.LogTrace($"response.StatusCode: {response!.StatusCode}");
                 logger.LogTrace($"response.contentType: {response!.ContentType}");
-                
+
                 if (response.ErrorMessage != null) logger.LogTrace($"response.ErrorMessage: {response!.ErrorMessage}");
 
                 ErrorResponse errorResponse = null;
@@ -144,6 +162,8 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             finally
             {
+                _restClient.Dispose();
+                _restClient = null;
                 logger.MethodExit();
             }
         }
@@ -161,7 +181,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 logger.LogError($"there was an error making the request: {LogHandler.FlattenException(ex)}");
                 throw;
             }
-            finally { logger.MethodExit(); }
+            finally
+            {
+                _restClient.Dispose();
+                _restClient = null;
+                logger.MethodExit();
+            }
         }
 
         /// <summary>
@@ -183,7 +208,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 logger.LogError($"request to get capabilities for token failed: {LogHandler.FlattenException(ex)}");
                 throw;
             }
-            finally { logger.MethodExit(); }
+            finally
+            {
+                _restClient.Dispose();
+                _restClient = null;
+                logger.MethodExit();
+            }
         }
     }
 }

--- a/hashicorp-vault-cagateway/Client/VaultHttp.cs
+++ b/hashicorp-vault-cagateway/Client/VaultHttp.cs
@@ -28,6 +28,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
         private string _authToken { get; set; }
         private string _nameSpace { get; set; }
         private JsonSerializerOptions _serializerOptions { get; set; }
+        private readonly ILogger logger;
 
         private RestClient _restClient;
         protected RestClient restClient
@@ -46,14 +47,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 logger.LogTrace($"namespace: {_nameSpace}");
                 return _restClient;
             }
-        }        
-
-        private static readonly ILogger logger = LogHandler.GetClassLogger<VaultHttp>();
+        }
 
         public VaultHttp(string host, string mountPoint, string authToken, string nameSpace = null)
         {
+            logger = LogHandler.GetClassLogger<VaultHttp>();
             logger.MethodEntry();
-
             _serializerOptions = new()
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
@@ -71,7 +70,6 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
 
             logger.LogTrace($"configured our httpclient wrapper with the following values:\nbase path: {_vaultApiPath}\nnamespace: {(!string.IsNullOrEmpty(_nameSpace) ? _nameSpace : "(no namespace configured)")}\nmount point: {_mountPoint}\nauth token: {_authToken.Substring(0, 8)}...");
-
             logger.MethodExit();
         }
 
@@ -87,7 +85,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
         {
             logger.MethodEntry();
             logger.LogTrace($"preparing to send GET request to {path} with parameters {JsonSerializer.Serialize(parameters)}");
-            logger.LogTrace($"will attempt to deserialize the response into a {typeof(T)}");
+            logger.LogTrace($"will attempt to deserialize the response into a {typeof(T).Name}");
             try
             {
                 var request = new RestRequest($"{_mountPoint}/{path}", Method.Get);
@@ -101,7 +99,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             catch (Exception ex)
             {
-                logger.LogError($"there was an error making the request: {LogHandler.FlattenException(ex)}");
+                logger.LogError($"there was an error making the GET request: {LogHandler.FlattenException(ex)}");
                 throw;
             }
             finally
@@ -132,7 +130,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
 
                 logger.LogTrace($"full url for the request: {restClient.Options.BaseUrl}/{request.Resource}");
 
-                var response = await _restClient.ExecutePostAsync<T>(request);
+                var response = await restClient.ExecutePostAsync<T>(request);
 
                 logger.LogTrace($"request completed. response returned:");
                 logger.LogTrace($"response.StatusCode: {response!.StatusCode}");
@@ -157,7 +155,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             catch (Exception ex)
             {
-                logger.LogError($"there was an error making the request: {LogHandler.FlattenException(ex)}");
+                logger.LogError($"there was an error making the POST request: {LogHandler.FlattenException(ex)}");
                 throw;
             }
             finally
@@ -177,7 +175,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
             }
             catch (Exception ex)
             {
-                logger.LogError($"there was an error making the request: {LogHandler.FlattenException(ex)}");
+                logger.LogError($"there was an error making the health-check request: {LogHandler.FlattenException(ex)}");
                 throw;
             }
             finally
@@ -185,36 +183,10 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault.Client
                 DisposeRestClient();
                 logger.MethodExit();
             }
-        }
-
-        /// <summary>
-        /// gets the capabilities for the current token in the given namespace.
-        /// using this method to verify connectivity
-        /// </summary>
-        /// <returns></returns>
-        public async Task<List<string>> GetCapabilitiesForThisTokenAndNamespace()
-        {
-            logger.MethodEntry();
-            try
-            {
-                var response = await _restClient.GetAsync<dynamic>("sys/capabilities/self");
-                response!.ThrowIfError();
-                return response.Content?.data?.capabilities as List<string>;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError($"request to get capabilities for token failed: {LogHandler.FlattenException(ex)}");
-                throw;
-            }
-            finally
-            {
-                DisposeRestClient();
-                logger.MethodExit();
-            }
-        }
+        }        
 
         private void DisposeRestClient() {
-            _restClient.Dispose();
+            _restClient?.Dispose();
             _restClient = null;
         }
     }

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -49,11 +49,10 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         public void Initialize(IAnyCAPluginConfigProvider configProvider, ICertificateDataReader certificateDataReader)
         {
             logger.MethodEntry(LogLevel.Trace);
-            string rawConfig = JsonSerializer.Serialize(configProvider.CAConnectionData);
-            logger.LogTrace($"serialized config: {rawConfig}");
-            _caConfig = JsonSerializer.Deserialize<HashicorpVaultCAConfig>(rawConfig);            
-            //_client = new HashicorpVaultClient(_caConfig);
             _certificateDataReader = certificateDataReader;
+            string rawConfig = JsonSerializer.Serialize(configProvider.CAConnectionData);            
+            logger.LogTrace($"serialized config: {rawConfig}");
+            _caConfig = JsonSerializer.Deserialize<HashicorpVaultCAConfig>(rawConfig);
             logger.MethodExit(LogLevel.Trace);
         }
 
@@ -225,7 +224,6 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// </summary>
         /// <param name="certificateDataReader">Provides information about the gateway's certificate database.</param>
         /// <param name="blockingBuffer">Buffer into which certificates are places from the CA.</param>
-        /// <param name="certificateAuthoritySyncInfo">Information about the last CA sync.</param>
         /// <param name="cancelToken">The cancellation token.</param>
         public async Task Synchronize(BlockingCollection<AnyCAPluginCertificate> blockingBuffer, DateTime? lastSync, bool fullSync, CancellationToken cancelToken)
         {            
@@ -235,17 +233,16 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             logger.MethodEntry();
             logger.LogTrace("Beginning Synchronization Task..");
 
-            var certSerials = new List<string>();
+            var certSerials = new BlockingCollection<string>();
             var count = 0;
             var changedCount = 0;
 
             var hashiClient = new HashicorpVaultClient(_caConfig);
 
             try
-            {
-                
+            {                
                 logger.LogTrace("getting all certificate serial numbers from vault");
-                certSerials = await hashiClient.GetAllCertSerialNumbers();
+                await hashiClient.GetAllCertSerialNumbers(certSerials, cancelToken);
             }
             catch (Exception ex)
             {
@@ -254,11 +251,21 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 throw;
             }
 
-            logger.LogTrace($"got {certSerials.Count()} serial numbers. Begin checking status for each...");
+            logger.LogTrace($"got {certSerials?.Count() ?? 0} serial numbers. Begin checking status for each...");
 
-            foreach (var certSerial in certSerials)
+            if (certSerials == null || certSerials.Count == 0) { // exit if no certs were found in vault
+                blockingBuffer.CompleteAdding();
+                logger.LogTrace($"no certificates found at path {_caConfig.Host} using namespace {_caConfig.Namespace} and mount point {_caConfig.MountPoint}");
+                logger.MethodExit();
+                return;
+            }
+
+            foreach (var certSerial in certSerials.GetConsumingEnumerable())
             {
-                cancelToken.ThrowIfCancellationRequested();
+                if (cancelToken.IsCancellationRequested)
+                {
+                    break;
+                }
                 CertResponse certFromVault = null;
                 var dbStatus = -1;
 
@@ -281,7 +288,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 // then, check for an existing local entry
                 try
                 {
-                    logger.LogTrace($"attempting to retreive status of cert with tracking id {trackingId} from the database");
+                    logger.LogTrace($"attempting to retreive status of cert with tracking id {trackingId} from the database");                    
                     dbStatus = await _certificateDataReader.GetStatusByRequestID(trackingId);
                 }
                 catch(Exception ex) // an exception is thrown if cert doesn't exist
@@ -320,6 +327,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     catch (Exception ex)
                     {
                         logger.LogError($"Failed to add the cert to the database: {LogHandler.FlattenException(ex)}");
+                        logger.LogTrace($"closing buffer and aborting sync");
                         blockingBuffer.CompleteAdding();
                         break;
                     }

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -70,6 +70,9 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         public async Task<EnrollmentResult> Enroll(string csr, string subject, Dictionary<string, string[]> san, EnrollmentProductInfo productInfo, RequestFormat requestFormat, EnrollmentType enrollmentType)
         {
             logger.MethodEntry(LogLevel.Trace);
+
+            _client = new HashicorpVaultClient(_caConfig);
+
             logger.LogInformation($"Begin {enrollmentType} enrollment for {subject}");
             string statusMessage;
             SignResponse signResponse;
@@ -142,6 +145,9 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 		public async Task<AnyCAPluginCertificate> GetSingleRecord(string caRequestID)
         {
             logger.MethodEntry();
+
+            _client = new HashicorpVaultClient(_caConfig);
+
             logger.LogTrace($"preparing to send request to retrieve certificate with id {caRequestID}");
             try
             {
@@ -176,6 +182,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         public async Task Ping()
         {
             logger.MethodEntry();
+            _client = new HashicorpVaultClient(_caConfig);
             logger.LogTrace("Attempting ping of Vault endpoint");
             try
             {
@@ -198,6 +205,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// <returns>The status of the request as an int representing EndEntityStatus</returns>
         public async Task<int> Revoke(string caRequestID, string hexSerialNumber, uint revocationReason)
         {
+            _client = new HashicorpVaultClient(_caConfig);
             logger.MethodEntry();
             logger.LogTrace($"Sending request to revoke certificate with id: {caRequestID}");
             try
@@ -223,6 +231,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// <param name="cancelToken">The cancellation token.</param>
         public async Task Synchronize(BlockingCollection<AnyCAPluginCertificate> blockingBuffer, DateTime? lastSync, bool fullSync, CancellationToken cancelToken)
         {
+            _client = new HashicorpVaultClient(_caConfig);
             // !! Any certificates issued outside of this CA Gateway will not necessarily be associated with the role name / (product ID) that was used to generate it
             // !! since that value is not retreivable after the initial generation.
 
@@ -247,6 +256,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
             foreach (var certSerial in certSerials)
             {
+                cancelToken.ThrowIfCancellationRequested();
                 CertResponse certFromVault = null;
                 var dbStatus = -1;
 
@@ -467,7 +477,6 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
         private async Task<bool> ProductIdIsValid(string productID, HashicorpVaultCAConfig config)
         {
-
             _client = new HashicorpVaultClient(config);
 
             // attempt an authenticated request to retreive role names

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -18,13 +18,16 @@ using System.Text.Json.Serialization;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 
 namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 {
     public class HashicorpVaultCAConnector : IAnyCAPlugin
     {
         private readonly ILogger logger;
+        private static int _threadLock = 0;
         private HashicorpVaultCAConfig _caConfig { get; set; }
+
         //private HashicorpVaultClient _client { get; set; }
         private ICertificateDataReader _certificateDataReader;
         private JsonSerializerOptions _serializerOptions;
@@ -46,11 +49,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// Initialize the <see cref="HashicorpVaultCAConnector"/>
         /// </summary>
         /// <param name="configProvider">The config provider contains information required to connect to the CA.</param>
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void Initialize(IAnyCAPluginConfigProvider configProvider, ICertificateDataReader certificateDataReader)
         {
             logger.MethodEntry(LogLevel.Trace);
             _certificateDataReader = certificateDataReader;
-            string rawConfig = JsonSerializer.Serialize(configProvider.CAConnectionData);            
+            string rawConfig = JsonSerializer.Serialize(configProvider.CAConnectionData);
             logger.LogTrace($"serialized config: {rawConfig}");
             _caConfig = JsonSerializer.Deserialize<HashicorpVaultCAConfig>(rawConfig);
             logger.MethodExit(LogLevel.Trace);
@@ -68,7 +72,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// <returns></returns>
         public async Task<EnrollmentResult> Enroll(string csr, string subject, Dictionary<string, string[]> san, EnrollmentProductInfo productInfo, RequestFormat requestFormat, EnrollmentType enrollmentType)
         {
-            logger.MethodEntry(LogLevel.Trace);            
+            logger.MethodEntry(LogLevel.Trace);
 
             logger.LogInformation($"Begin {enrollmentType} enrollment for {subject}");
             string statusMessage;
@@ -143,7 +147,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         {
             logger.MethodEntry();
 
-            var hashiClient  = new HashicorpVaultClient(_caConfig);
+            var hashiClient = new HashicorpVaultClient(_caConfig);
 
             logger.LogTrace($"preparing to send request to retrieve certificate with id {caRequestID}");
             try
@@ -224,25 +228,32 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// </summary>
         /// <param name="certificateDataReader">Provides information about the gateway's certificate database.</param>
         /// <param name="blockingBuffer">Buffer into which certificates are places from the CA.</param>
-        /// <param name="cancelToken">The cancellation token.</param>
+        /// <param name="cancelToken">The cancellation token.</param>        
         public async Task Synchronize(BlockingCollection<AnyCAPluginCertificate> blockingBuffer, DateTime? lastSync, bool fullSync, CancellationToken cancelToken)
-        {            
+        {
             // !! Any certificates issued outside of this CA Gateway will not necessarily be associated with the role name / (product ID) that was used to generate it
             // !! since that value is not retreivable after the initial generation.
 
             logger.MethodEntry();
             logger.LogTrace("Beginning Synchronization Task..");
 
-            var certSerials = new BlockingCollection<string>();
+            var certSerials = new List<string>();
             var count = 0;
             var changedCount = 0;
 
-            var hashiClient = new HashicorpVaultClient(_caConfig);
+            HashicorpVaultClient hashiClient;
+
+            logger.LogTrace("attempt locking of _caConfig.");
+            Monitor.Enter(_caConfig);
+
 
             try
-            {                
+            {
+                
+                hashiClient = new HashicorpVaultClient(_caConfig);
                 logger.LogTrace($"getting all certificate serial numbers from vault from {_caConfig.Host} using namespace {_caConfig.Namespace} and mount-point {_caConfig.MountPoint}");
-                await hashiClient.GetAllCertSerialNumbers(certSerials, cancelToken);
+                var serials = hashiClient.GetAllCertSerialNumbers(cancelToken).Result;
+                Interlocked.Exchange(ref certSerials, serials);
             }
             catch (Exception ex)
             {
@@ -250,17 +261,22 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 blockingBuffer.CompleteAdding();
                 throw;
             }
+            finally
+            {
+                Monitor.Exit(_caConfig);
+            }
 
             logger.LogTrace($"got {certSerials?.Count() ?? 0} serial numbers. Begin checking status for each...");
 
-            if (certSerials == null || certSerials.Count == 0) { // exit if no certs were found in vault
+            if (certSerials == null || certSerials.Count == 0)
+            { // exit if no certs were found in vault
                 blockingBuffer.CompleteAdding();
                 logger.LogTrace($"no certificates found at path {_caConfig.Host} using namespace {_caConfig.Namespace} and mount point {_caConfig.MountPoint}");
                 logger.MethodExit();
-                return;
+                return;                
             }
 
-            foreach (var certSerial in certSerials.GetConsumingEnumerable())
+            foreach (var certSerial in certSerials)
             {
                 if (cancelToken.IsCancellationRequested)
                 {
@@ -281,6 +297,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     blockingBuffer.CompleteAdding();
                     throw;
                 }
+                finally { Monitor.Exit(_caConfig); }
                 logger.LogTrace($"converting {certSerial} to database trackingId");
 
                 var trackingId = certSerial.Replace(":", "-"); // we store with '-'; hashi stores with ':'
@@ -288,23 +305,25 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 // then, check for an existing local entry
                 try
                 {
-                    logger.LogTrace($"attempting to retreive status of cert with tracking id {trackingId} from the database");                    
+                    logger.LogTrace($"attempting to retreive status of cert with tracking id {trackingId} from the database");
                     dbStatus = await _certificateDataReader.GetStatusByRequestID(trackingId);
                 }
-                catch(Exception ex) // an exception is thrown if cert doesn't exist
-                {   
-                    if (!ex.Message.Contains("No matching")) { // if the exception message doesn't contain this; something else happened.
+                catch (Exception ex) // an exception is thrown if cert doesn't exist
+                {
+                    if (!ex.Message.Contains("No matching"))
+                    { // if the exception message doesn't contain this; something else happened.
                         logger.LogTrace($"exception when retrieving cert from database: {ex.Message}");
                         blockingBuffer.CompleteAdding();
                         throw;
                     }
                     logger.LogTrace($"tracking id {trackingId} was not found in the database.  it will be added.");
                 }
+                finally { Monitor.Exit(_caConfig); }
 
                 if (dbStatus == -1 || fullSync) // it's missing and needs added, or a full sync is requested
                 {
                     logger.LogTrace($"adding cert with serial {trackingId} to the database.  fullsync is {fullSync}, and the certificate {(dbStatus == -1 ? "does not yet exist" : "already exists")} in the database.");
-                    changedCount++;
+                    Interlocked.Increment(ref changedCount);
                     var newCert = new AnyCAPluginCertificate
                     {
                         CARequestID = trackingId,
@@ -320,9 +339,10 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                         {
                             logger.LogTrace($"successfully added certificate to the database.");
                         }
-                        else {
+                        else
+                        {
                             logger.LogTrace($"adding to queue for writing was blocked.");
-                        }                        
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -331,6 +351,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                         blockingBuffer.CompleteAdding();
                         throw;
                     }
+                    finally { Monitor.Exit(_caConfig); }
                 }
                 else // the cert exists in the database; just update the status if necessary
                 {
@@ -339,7 +360,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     var vaultStatus = revoked ? (int)EndEntityStatus.REVOKED : (int)EndEntityStatus.GENERATED;
                     if (vaultStatus != dbStatus) // if there is a mismatch, we need to update
                     {
-                        changedCount++;
+                        Interlocked.Increment(ref changedCount);
                         logger.LogTrace($"status in vault is {vaultStatus}, status in db is {dbStatus}; updating db.");
                         var newCert = new AnyCAPluginCertificate
                         {
@@ -358,15 +379,17 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                             logger.LogTrace($"adding to queue for writing was blocked.");
                         }
                     }
-                    else {
+                    else
+                    {
                         logger.LogTrace($"The status is unchanged and we are doing an incremental scan; no need to update db.");
                     }
                 }
-                count++;
+                Interlocked.Increment(ref count);
             }
             blockingBuffer.CompleteAdding();
             logger.LogTrace($"Completed sync of {count} certificates.  It was {(fullSync ? "a full" : "an incremental")} sync and {changedCount} records were updated.");
             logger.MethodExit();
+            Monitor.Exit(_caConfig);
         }
 
         /// <summary>
@@ -621,7 +644,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         public List<string> GetProductIds()
         {
             logger.MethodEntry();
-            var hashiClient = new HashicorpVaultClient(_caConfig);            
+            var hashiClient = new HashicorpVaultClient(_caConfig);
             try
             {
                 logger.LogTrace("requesting role names from vault..");

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -248,6 +248,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             catch (Exception ex)
             {
                 logger.LogError($"failed to retreive serial numbers: {LogHandler.FlattenException(ex)}");
+                blockingBuffer.CompleteAdding();
                 throw;
             }
 
@@ -268,6 +269,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 catch (Exception ex)
                 {
                     logger.LogError($"Failed to retreive details for certificate with serial number {certSerial} from Vault.  Errors: {LogHandler.FlattenException(ex)}");
+                    blockingBuffer.CompleteAdding();
                     throw;
                 }
                 logger.LogTrace($"converting {certSerial} to database trackingId");
@@ -284,6 +286,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 {   
                     if (!ex.Message.Contains("No matching")) { // if the exception message doesn't contain this; something else happened.
                         logger.LogTrace($"exception when retrieving cert from database: {ex.Message}");
+                        blockingBuffer.CompleteAdding();
                         throw;
                     }
                     logger.LogTrace($"tracking id {trackingId} was not found in the database.  it will be added.");
@@ -304,13 +307,19 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     try
                     {
                         logger.LogTrace($"writing the result.");
-                        blockingBuffer.Add(newCert);
-                        logger.LogTrace($"successfully added certificate to the database.");
+                        if (blockingBuffer.TryAdd(newCert, 50, cancelToken))
+                        {
+                            logger.LogTrace($"successfully added certificate to the database.");
+                        }
+                        else {
+                            logger.LogTrace($"adding to queue for writing was blocked.");
+                        }                        
                     }
                     catch (Exception ex)
                     {
                         logger.LogError($"Failed to add the cert to the database: {LogHandler.FlattenException(ex)}");
-                        throw;
+                        blockingBuffer.CompleteAdding();
+                        break;
                     }
                 }
                 else // the cert exists in the database; just update the status if necessary
@@ -330,6 +339,14 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                             RevocationDate = certFromVault.RevocationTime
                             // ProductID is not available via the API after the initial issuance.  we do not want to overwrite                            
                         };
+                        if (blockingBuffer.TryAdd(newCert, 50, cancelToken))
+                        {
+                            logger.LogTrace($"successfully updated certificate {trackingId} in the database.");
+                        }
+                        else
+                        {
+                            logger.LogTrace($"adding to queue for writing was blocked.");
+                        }
                     }
                     else {
                         logger.LogTrace($"The status is unchanged and we are doing an incremental scan; no need to update db.");
@@ -337,6 +354,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 }
                 count++;
             }
+            blockingBuffer.CompleteAdding();
             logger.LogTrace($"Completed sync of {count} certificates.  It was {(fullSync ? "a full" : "an incremental")} sync and {changedCount} records were updated.");
             logger.MethodExit();
         }

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -25,7 +25,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
     {
         private readonly ILogger logger;
         private HashicorpVaultCAConfig _caConfig { get; set; }
-        private HashicorpVaultClient _client { get; set; }
+        //private HashicorpVaultClient _client { get; set; }
         private ICertificateDataReader _certificateDataReader;
         private JsonSerializerOptions _serializerOptions;
 
@@ -53,7 +53,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             logger.LogTrace($"serialized config: {rawConfig}");
             _caConfig = JsonSerializer.Deserialize<HashicorpVaultCAConfig>(rawConfig);
             logger.MethodExit(LogLevel.Trace);
-            _client = new HashicorpVaultClient(_caConfig);
+            //_client = new HashicorpVaultClient(_caConfig);
             _certificateDataReader = certificateDataReader;
         }
 
@@ -69,9 +69,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// <returns></returns>
         public async Task<EnrollmentResult> Enroll(string csr, string subject, Dictionary<string, string[]> san, EnrollmentProductInfo productInfo, RequestFormat requestFormat, EnrollmentType enrollmentType)
         {
-            logger.MethodEntry(LogLevel.Trace);
-
-            _client = new HashicorpVaultClient(_caConfig);
+            logger.MethodEntry(LogLevel.Trace);            
 
             logger.LogInformation($"Begin {enrollmentType} enrollment for {subject}");
             string statusMessage;
@@ -87,7 +85,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
                 // create the client
                 logger.LogTrace("instantiating the client..");
-                _client = new HashicorpVaultClient(_caConfig, templateConfig);
+                var hashiClient = new HashicorpVaultClient(_caConfig, templateConfig);
 
                 logger.LogDebug("Parse subject for Common Name");
                 string commonName = ParseSubject(subject, "CN=");
@@ -97,7 +95,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
                 logger.LogTrace($"using vault role name {vaultRole}");
 
-                signResponse = await _client.SignCSR(csr, subject, san, vaultRole);
+                signResponse = await hashiClient.SignCSR(csr, subject, san, vaultRole);
 
                 // trace logs
                 logger.LogTrace($"back to calling method");
@@ -146,12 +144,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         {
             logger.MethodEntry();
 
-            _client = new HashicorpVaultClient(_caConfig);
+            var hashiClient  = new HashicorpVaultClient(_caConfig);
 
             logger.LogTrace($"preparing to send request to retrieve certificate with id {caRequestID}");
             try
             {
-                var cert = await _client.GetCertificate(caRequestID);
+                var cert = await hashiClient.GetCertificate(caRequestID);
 
                 logger.LogTrace($"got a response from the request..");
                 logger.LogTrace($"revocation time: {cert.RevocationTime}");
@@ -182,11 +180,11 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         public async Task Ping()
         {
             logger.MethodEntry();
-            _client = new HashicorpVaultClient(_caConfig);
+            var hashiClient = new HashicorpVaultClient(_caConfig);
             logger.LogTrace("Attempting ping of Vault endpoint");
             try
             {
-                var result = await _client.PingServer();
+                var result = await hashiClient.PingServer();
             }
             catch (Exception ex)
             {
@@ -205,12 +203,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// <returns>The status of the request as an int representing EndEntityStatus</returns>
         public async Task<int> Revoke(string caRequestID, string hexSerialNumber, uint revocationReason)
         {
-            _client = new HashicorpVaultClient(_caConfig);
+            var hashiClient = new HashicorpVaultClient(_caConfig);
             logger.MethodEntry();
             logger.LogTrace($"Sending request to revoke certificate with id: {caRequestID}");
             try
             {
-                var response = await _client.RevokeCertificate(caRequestID);
+                var response = await hashiClient.RevokeCertificate(caRequestID);
                 logger.LogTrace($"returning 'REVOKED' EndEntityStatus ({(int)EndEntityStatus.REVOKED})");
                 return (int)EndEntityStatus.REVOKED;
             }
@@ -231,7 +229,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// <param name="cancelToken">The cancellation token.</param>
         public async Task Synchronize(BlockingCollection<AnyCAPluginCertificate> blockingBuffer, DateTime? lastSync, bool fullSync, CancellationToken cancelToken)
         {
-            _client = new HashicorpVaultClient(_caConfig);
+            var hashiClient = new HashicorpVaultClient(_caConfig);
             // !! Any certificates issued outside of this CA Gateway will not necessarily be associated with the role name / (product ID) that was used to generate it
             // !! since that value is not retreivable after the initial generation.
 
@@ -245,7 +243,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             try
             {
                 logger.LogTrace("getting all certificate serial numbers from vault");
-                certSerials = await _client.GetAllCertSerialNumbers();
+                certSerials = await hashiClient.GetAllCertSerialNumbers();
             }
             catch (Exception ex)
             {
@@ -265,7 +263,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 try
                 {
                     logger.LogTrace($"Calling GetCertificate on our client, passing serial number: {certSerial}");
-                    certFromVault = await _client.GetCertificate(certSerial);
+                    certFromVault = await hashiClient.GetCertificate(certSerial);
                 }
                 catch (Exception ex)
                 {
@@ -282,9 +280,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     logger.LogTrace($"attempting to retreive status of cert with tracking id {trackingId} from the database");
                     dbStatus = await _certificateDataReader.GetStatusByRequestID(trackingId);
                 }
-                catch(Exception ex)
-                {
-                    logger.LogTrace($"exception when retrieving cert from DB.  It could simply be missing, but logging for analysis: {ex.Message}");
+                catch(Exception ex) // an exception is thrown if cert doesn't exist
+                {   
+                    if (!ex.Message.Contains("No matching")) { // if the exception message doesn't contain this; something else happened.
+                        logger.LogTrace($"exception when retrieving cert from database: {ex.Message}");
+                        throw;
+                    }
                     logger.LogTrace($"tracking id {trackingId} was not found in the database.  it will be added.");
                 }
 
@@ -419,13 +420,13 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
             // create an instance of our client with those values
 
-            _client = new HashicorpVaultClient(config);
+            var hashiClient = new HashicorpVaultClient(config);
 
             // attempt an authenticated request to retreive role names
             try
             {
                 logger.LogTrace("making an authenticated request to the Vault server to verify credentials (listing role names)..");
-                var roleNames = await _client.GetRoleNamesAsync();
+                var roleNames = await hashiClient.GetRoleNamesAsync();
                 logger.LogTrace($"successfule request: received a response containing {roleNames.Count} role names");
             }
             catch (Exception ex)
@@ -485,13 +486,13 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
         private async Task<bool> ProductIdIsValid(string productID, HashicorpVaultCAConfig config)
         {
-            _client = new HashicorpVaultClient(config);
+            var hashiClient = new HashicorpVaultClient(config);
 
             // attempt an authenticated request to retreive role names
             try
             {
                 logger.LogTrace("making an authenticated request to the Vault server to verify credentials (listing role names)..");
-                var roleNames = await _client.GetRoleNamesAsync();
+                var roleNames = await hashiClient.GetRoleNamesAsync();
                 logger.LogTrace($"successfule request: received a response containing {roleNames.Count} role names");
                 return roleNames.Any(rn => rn == productID);
             }
@@ -592,11 +593,11 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         public List<string> GetProductIds()
         {
             logger.MethodEntry();
-            // Initialize should have been called in order to populate the caConfig and create the client.
+            var hashiClient = new HashicorpVaultClient(_caConfig);            
             try
             {
                 logger.LogTrace("requesting role names from vault..");
-                var roleNames = _client.GetRoleNamesAsync().Result;
+                var roleNames = hashiClient.GetRoleNamesAsync().Result;
                 logger.LogTrace($"got {roleNames.Count} role names from vault:");
                 foreach (var name in roleNames)
                 {

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -352,18 +352,22 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
             // make sure an authentication mechanism is defined (either certificate or token)
             var token = connectionInfo[Constants.CAConfig.TOKEN] as string;
-            var cert = connectionInfo[Constants.CAConfig.CLIENTCERT] as string;
+            
+            /// REMOVING CERT VALIDATION UNTIL CLIENT CERT AUTH IS IMPLEMENTED
+            
+            //var cert = connectionInfo[Constants.CAConfig.CLIENTCERT] as string;
 
-            if (string.IsNullOrEmpty(token) && string.IsNullOrEmpty(cert))
-            {
-                errors.Add("Either an authentication token or client certificate must be defined for authentication into Vault.");
-            }
-            if (!string.IsNullOrEmpty(token) && !string.IsNullOrEmpty(cert))
-            {
-                logger.LogWarning("Both an authentication token and client certificate are defined.  Using the token for authentication.");
-            }
+            //if (string.IsNullOrEmpty(token) && string.IsNullOrEmpty(cert))
+            //{
+            //    errors.Add("Either an authentication token or client certificate must be defined for authentication into Vault.");
+            //}
+            //if (!string.IsNullOrEmpty(token) && !string.IsNullOrEmpty(cert))
+            //{
+            //    logger.LogWarning("Both an authentication token and client certificate are defined.  Using the token for authentication.");
+            //}
 
             // if any errors, throw
+
             if (errors.Any())
             {
                 var allErrors = string.Join("\n", errors);

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -51,10 +51,10 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             logger.MethodEntry(LogLevel.Trace);
             string rawConfig = JsonSerializer.Serialize(configProvider.CAConnectionData);
             logger.LogTrace($"serialized config: {rawConfig}");
-            _caConfig = JsonSerializer.Deserialize<HashicorpVaultCAConfig>(rawConfig);
-            logger.MethodExit(LogLevel.Trace);
+            _caConfig = JsonSerializer.Deserialize<HashicorpVaultCAConfig>(rawConfig);            
             //_client = new HashicorpVaultClient(_caConfig);
             _certificateDataReader = certificateDataReader;
+            logger.MethodExit(LogLevel.Trace);
         }
 
         /// <summary>
@@ -228,8 +228,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         /// <param name="certificateAuthoritySyncInfo">Information about the last CA sync.</param>
         /// <param name="cancelToken">The cancellation token.</param>
         public async Task Synchronize(BlockingCollection<AnyCAPluginCertificate> blockingBuffer, DateTime? lastSync, bool fullSync, CancellationToken cancelToken)
-        {
-            var hashiClient = new HashicorpVaultClient(_caConfig);
+        {            
             // !! Any certificates issued outside of this CA Gateway will not necessarily be associated with the role name / (product ID) that was used to generate it
             // !! since that value is not retreivable after the initial generation.
 
@@ -240,8 +239,11 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             var count = 0;
             var changedCount = 0;
 
+            var hashiClient = new HashicorpVaultClient(_caConfig);
+
             try
             {
+                
                 logger.LogTrace("getting all certificate serial numbers from vault");
                 certSerials = await hashiClient.GetAllCertSerialNumbers();
             }
@@ -264,7 +266,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 try
                 {
                     logger.LogTrace($"Calling GetCertificate on our client, passing serial number: {certSerial}");
-                    certFromVault = await hashiClient.GetCertificate(certSerial);
+                    certFromVault = hashiClient.GetCertificate(certSerial).Result;
                 }
                 catch (Exception ex)
                 {

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -54,12 +54,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             _caConfig = JsonSerializer.Deserialize<HashicorpVaultCAConfig>(rawConfig);
             logger.MethodExit(LogLevel.Trace);
             _client = new HashicorpVaultClient(_caConfig);
+            _certificateDataReader = certificateDataReader;
         }
 
         /// <summary>
         /// Enrolls for a certificate through the API.
         /// </summary>
-        /// <param name="certificateDataReader">Reads certificate data from the database.</param>
         /// <param name="csr">The certificate request CSR in PEM format.</param>
         /// <param name="subject">The subject of the certificate request.</param>
         /// <param name="san">Any SANs added to the request.</param>

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -352,9 +352,9 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
             // make sure an authentication mechanism is defined (either certificate or token)
             var token = connectionInfo[Constants.CAConfig.TOKEN] as string;
-            
+
             /// REMOVING CERT VALIDATION UNTIL CLIENT CERT AUTH IS IMPLEMENTED
-            
+
             //var cert = connectionInfo[Constants.CAConfig.CLIENTCERT] as string;
 
             //if (string.IsNullOrEmpty(token) && string.IsNullOrEmpty(cert))
@@ -443,10 +443,15 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 logger.LogError(LogHandler.FlattenException(ex));
                 throw;
             }
-            // make sure Role Name is present in the template config
-            if (string.IsNullOrEmpty(productInfo.ProductParameters[Constants.TemplateConfig.ROLENAME] as string))
+            // make sure product ID is a valid RoleName
+            if (string.IsNullOrEmpty(productInfo.ProductID))
             {
-                errors.Add($"The '{Constants.TemplateConfig.ROLENAME}' is required.");
+                errors.Add($"The productID is required.");
+            }
+
+            if (!ProductIdIsValid(productInfo.ProductID, caConfig).Result)
+            {
+                errors.Add($"The productID {productInfo.ProductID} does not match any of the role names defined in Vault.");
             }
 
             // if any errors, throw
@@ -458,6 +463,27 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             }
             logger.MethodExit();
             return Task.CompletedTask;
+        }
+
+        private async Task<bool> ProductIdIsValid(string productID, HashicorpVaultCAConfig config)
+        {
+
+            _client = new HashicorpVaultClient(config);
+
+            // attempt an authenticated request to retreive role names
+            try
+            {
+                logger.LogTrace("making an authenticated request to the Vault server to verify credentials (listing role names)..");
+                var roleNames = await _client.GetRoleNamesAsync();
+                logger.LogTrace($"successfule request: received a response containing {roleNames.Count} role names");
+                return roleNames.Any(rn => rn == productID);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError($"Authenticated request failed.  {ex.Message}");
+                throw;
+            }
+            finally { logger.MethodExit(); }
         }
 
         /// <summary>

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -25,7 +25,6 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
     public class HashicorpVaultCAConnector : IAnyCAPlugin
     {
         private readonly ILogger logger;
-        private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1); // Binary semaphore (1 indicates only one thread/task can enter)
         private HashicorpVaultCAConfig _caConfig;
 
         //private HashicorpVaultClient _client { get; set; }
@@ -235,10 +234,6 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             // !! since that value is not retreivable after the initial generation.
             logger.MethodEntry();
 
-            await _semaphore.WaitAsync(cancelToken);
-
-            logger.LogTrace($"got semaphore lock, current count: {_semaphore.CurrentCount}");
-
             logger.LogTrace("Beginning Synchronization Task..");
 
             var certSerials = new List<string>();
@@ -260,8 +255,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 catch (Exception ex)
                 {
                     logger.LogError($"failed to retreive serial numbers: {LogHandler.FlattenException(ex)}");
-                    blockingBuffer.CompleteAdding();
-                    _semaphore.Release();
+                    blockingBuffer.CompleteAdding();                    
                     throw;
                 }
 
@@ -270,8 +264,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 if (certSerials == null || certSerials.Count == 0)
                 { // exit if no certs were found in vault
                     blockingBuffer.CompleteAdding();
-                    logger.LogTrace($"no certificates found at path {_caConfig.Host} using namespace {_caConfig.Namespace} and mount point {_caConfig.MountPoint}");
-                    _semaphore.Release();
+                    logger.LogTrace($"no certificates found at path {_caConfig.Host} using namespace {_caConfig.Namespace} and mount point {_caConfig.MountPoint}");                    
                     logger.MethodExit();                    
                     return;
                 }
@@ -294,8 +287,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     catch (Exception ex)
                     {
                         logger.LogError($"Failed to retreive details for certificate with serial number {certSerial} from Vault.  Errors: {LogHandler.FlattenException(ex)}");
-                        blockingBuffer.CompleteAdding();
-                        _semaphore.Release();
+                        blockingBuffer.CompleteAdding();                        
                         throw;
                     }
                     logger.LogTrace($"converting {certSerial} to database trackingId");
@@ -313,8 +305,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                         if (!ex.Message.Contains("No matching"))
                         { // if the exception message doesn't contain this; something else happened.
                             logger.LogTrace($"exception when retrieving cert from database: {ex.Message}");
-                            blockingBuffer.CompleteAdding();
-                            _semaphore.Release();
+                            blockingBuffer.CompleteAdding();                            
                             throw;
                         }
                         logger.LogTrace($"tracking id {trackingId} was not found in the database.  it will be added.");
@@ -348,8 +339,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                         {
                             logger.LogError($"Failed to add the cert to the database: {LogHandler.FlattenException(ex)}");
                             logger.LogTrace($"closing buffer and aborting sync");
-                            blockingBuffer.CompleteAdding();
-                            _semaphore.Release();
+                            blockingBuffer.CompleteAdding();                            
                             throw;
                         }
                     }
@@ -391,7 +381,6 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
             }
             finally
             {
-                _semaphore.Release();
                 logger.MethodExit();
             }            
         }

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -25,8 +25,8 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
     public class HashicorpVaultCAConnector : IAnyCAPlugin
     {
         private readonly ILogger logger;
-        private static int _threadLock = 0;
-        private HashicorpVaultCAConfig _caConfig { get; set; }
+        private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1); // Binary semaphore (1 indicates only one thread/task can enter)
+        private HashicorpVaultCAConfig _caConfig;
 
         //private HashicorpVaultClient _client { get; set; }
         private ICertificateDataReader _certificateDataReader;
@@ -233,8 +233,12 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
         {
             // !! Any certificates issued outside of this CA Gateway will not necessarily be associated with the role name / (product ID) that was used to generate it
             // !! since that value is not retreivable after the initial generation.
-
             logger.MethodEntry();
+
+            await _semaphore.WaitAsync(cancelToken);
+
+            logger.LogTrace($"got semaphore lock, current count: {_semaphore.CurrentCount}");
+
             logger.LogTrace("Beginning Synchronization Task..");
 
             var certSerials = new List<string>();
@@ -243,153 +247,153 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
             HashicorpVaultClient hashiClient;
 
-            logger.LogTrace("attempt locking of _caConfig.");
-            Monitor.Enter(_caConfig);
-
-
             try
-            {
-                
-                hashiClient = new HashicorpVaultClient(_caConfig);
-                logger.LogTrace($"getting all certificate serial numbers from vault from {_caConfig.Host} using namespace {_caConfig.Namespace} and mount-point {_caConfig.MountPoint}");
-                var serials = hashiClient.GetAllCertSerialNumbers(cancelToken).Result;
-                Interlocked.Exchange(ref certSerials, serials);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError($"failed to retreive serial numbers: {LogHandler.FlattenException(ex)}");
-                blockingBuffer.CompleteAdding();
-                throw;
-            }
-            finally
-            {
-                Monitor.Exit(_caConfig);
-            }
+            { // wrapper for single thread block
 
-            logger.LogTrace($"got {certSerials?.Count() ?? 0} serial numbers. Begin checking status for each...");
-
-            if (certSerials == null || certSerials.Count == 0)
-            { // exit if no certs were found in vault
-                blockingBuffer.CompleteAdding();
-                logger.LogTrace($"no certificates found at path {_caConfig.Host} using namespace {_caConfig.Namespace} and mount point {_caConfig.MountPoint}");
-                logger.MethodExit();
-                return;                
-            }
-
-            foreach (var certSerial in certSerials)
-            {
-                if (cancelToken.IsCancellationRequested)
-                {
-                    break;
-                }
-                CertResponse certFromVault = null;
-                var dbStatus = -1;
-
-                // first, retreive the details from Vault
                 try
                 {
-                    logger.LogTrace($"Calling GetCertificate on our client, passing serial number: {certSerial}");
-                    certFromVault = hashiClient.GetCertificate(certSerial).Result;
+
+                    hashiClient = new HashicorpVaultClient(_caConfig);
+                    logger.LogTrace($"getting all certificate serial numbers from vault from {_caConfig.Host} using namespace {_caConfig.Namespace} and mount-point {_caConfig.MountPoint}");
+                    certSerials = await hashiClient.GetAllCertSerialNumbers(cancelToken);
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError($"Failed to retreive details for certificate with serial number {certSerial} from Vault.  Errors: {LogHandler.FlattenException(ex)}");
+                    logger.LogError($"failed to retreive serial numbers: {LogHandler.FlattenException(ex)}");
                     blockingBuffer.CompleteAdding();
+                    _semaphore.Release();
                     throw;
                 }
-                finally { Monitor.Exit(_caConfig); }
-                logger.LogTrace($"converting {certSerial} to database trackingId");
 
-                var trackingId = certSerial.Replace(":", "-"); // we store with '-'; hashi stores with ':'
+                logger.LogTrace($"got {certSerials?.Count() ?? 0} serial numbers. Begin checking status for each...");
 
-                // then, check for an existing local entry
-                try
-                {
-                    logger.LogTrace($"attempting to retreive status of cert with tracking id {trackingId} from the database");
-                    dbStatus = await _certificateDataReader.GetStatusByRequestID(trackingId);
+                if (certSerials == null || certSerials.Count == 0)
+                { // exit if no certs were found in vault
+                    blockingBuffer.CompleteAdding();
+                    logger.LogTrace($"no certificates found at path {_caConfig.Host} using namespace {_caConfig.Namespace} and mount point {_caConfig.MountPoint}");
+                    _semaphore.Release();
+                    logger.MethodExit();                    
+                    return;
                 }
-                catch (Exception ex) // an exception is thrown if cert doesn't exist
-                {
-                    if (!ex.Message.Contains("No matching"))
-                    { // if the exception message doesn't contain this; something else happened.
-                        logger.LogTrace($"exception when retrieving cert from database: {ex.Message}");
-                        blockingBuffer.CompleteAdding();
-                        throw;
-                    }
-                    logger.LogTrace($"tracking id {trackingId} was not found in the database.  it will be added.");
-                }
-                finally { Monitor.Exit(_caConfig); }
 
-                if (dbStatus == -1 || fullSync) // it's missing and needs added, or a full sync is requested
+                foreach (var certSerial in certSerials)
                 {
-                    logger.LogTrace($"adding cert with serial {trackingId} to the database.  fullsync is {fullSync}, and the certificate {(dbStatus == -1 ? "does not yet exist" : "already exists")} in the database.");
-                    Interlocked.Increment(ref changedCount);
-                    var newCert = new AnyCAPluginCertificate
+                    if (cancelToken.IsCancellationRequested)
                     {
-                        CARequestID = trackingId,
-                        Certificate = certFromVault.Certificate,
-                        Status = certFromVault.RevocationTime != null ? (int)EndEntityStatus.REVOKED : (int)EndEntityStatus.GENERATED,
-                        RevocationDate = certFromVault.RevocationTime,
-                    };
+                        break;
+                    }
+                    CertResponse certFromVault = null;
+                    var dbStatus = -1;
 
+                    // first, retreive the details from Vault
                     try
                     {
-                        logger.LogTrace($"writing the result.");
-                        if (blockingBuffer.TryAdd(newCert, 50, cancelToken))
-                        {
-                            logger.LogTrace($"successfully added certificate to the database.");
-                        }
-                        else
-                        {
-                            logger.LogTrace($"adding to queue for writing was blocked.");
-                        }
+                        logger.LogTrace($"Calling GetCertificate on our client, passing serial number: {certSerial}");
+                        certFromVault = hashiClient.GetCertificate(certSerial).Result;
                     }
                     catch (Exception ex)
                     {
-                        logger.LogError($"Failed to add the cert to the database: {LogHandler.FlattenException(ex)}");
-                        logger.LogTrace($"closing buffer and aborting sync");
+                        logger.LogError($"Failed to retreive details for certificate with serial number {certSerial} from Vault.  Errors: {LogHandler.FlattenException(ex)}");
                         blockingBuffer.CompleteAdding();
+                        _semaphore.Release();
                         throw;
                     }
-                    finally { Monitor.Exit(_caConfig); }
-                }
-                else // the cert exists in the database; just update the status if necessary
-                {
-                    logger.LogTrace($"certificate with id {trackingId} was found in the database, comparing status.");
-                    var revoked = certFromVault.RevocationTime != null;
-                    var vaultStatus = revoked ? (int)EndEntityStatus.REVOKED : (int)EndEntityStatus.GENERATED;
-                    if (vaultStatus != dbStatus) // if there is a mismatch, we need to update
+                    logger.LogTrace($"converting {certSerial} to database trackingId");
+
+                    var trackingId = certSerial.Replace(":", "-"); // we store with '-'; hashi stores with ':'
+
+                    // then, check for an existing local entry
+                    try
                     {
-                        Interlocked.Increment(ref changedCount);
-                        logger.LogTrace($"status in vault is {vaultStatus}, status in db is {dbStatus}; updating db.");
+                        logger.LogTrace($"attempting to retreive status of cert with tracking id {trackingId} from the database");
+                        dbStatus = await _certificateDataReader.GetStatusByRequestID(trackingId);
+                    }
+                    catch (Exception ex) // an exception is thrown if cert doesn't exist
+                    {
+                        if (!ex.Message.Contains("No matching"))
+                        { // if the exception message doesn't contain this; something else happened.
+                            logger.LogTrace($"exception when retrieving cert from database: {ex.Message}");
+                            blockingBuffer.CompleteAdding();
+                            _semaphore.Release();
+                            throw;
+                        }
+                        logger.LogTrace($"tracking id {trackingId} was not found in the database.  it will be added.");
+                    }
+
+                    if (dbStatus == -1 || fullSync) // it's missing and needs added, or a full sync is requested
+                    {
+                        logger.LogTrace($"adding cert with serial {trackingId} to the database.  fullsync is {fullSync}, and the certificate {(dbStatus == -1 ? "does not yet exist" : "already exists")} in the database.");
+                        changedCount++;
                         var newCert = new AnyCAPluginCertificate
                         {
                             CARequestID = trackingId,
                             Certificate = certFromVault.Certificate,
-                            Status = vaultStatus,
-                            RevocationDate = certFromVault.RevocationTime
-                            // ProductID is not available via the API after the initial issuance.  we do not want to overwrite                            
+                            Status = certFromVault.RevocationTime != null ? (int)EndEntityStatus.REVOKED : (int)EndEntityStatus.GENERATED,
+                            RevocationDate = certFromVault.RevocationTime,
                         };
-                        if (blockingBuffer.TryAdd(newCert, 50, cancelToken))
+
+                        try
                         {
-                            logger.LogTrace($"successfully updated certificate {trackingId} in the database.");
+                            logger.LogTrace($"writing the result.");
+                            if (blockingBuffer.TryAdd(newCert, 50, cancelToken))
+                            {
+                                logger.LogTrace($"successfully added certificate to the database.");
+                            }
+                            else
+                            {
+                                logger.LogTrace($"adding to queue for writing was blocked.");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogError($"Failed to add the cert to the database: {LogHandler.FlattenException(ex)}");
+                            logger.LogTrace($"closing buffer and aborting sync");
+                            blockingBuffer.CompleteAdding();
+                            _semaphore.Release();
+                            throw;
+                        }
+                    }
+                    else // the cert exists in the database; just update the status if necessary
+                    {
+                        logger.LogTrace($"certificate with id {trackingId} was found in the database, comparing status.");
+                        var revoked = certFromVault.RevocationTime != null;
+                        var vaultStatus = revoked ? (int)EndEntityStatus.REVOKED : (int)EndEntityStatus.GENERATED;
+                        if (vaultStatus != dbStatus) // if there is a mismatch, we need to update
+                        {
+                            changedCount++;
+                            logger.LogTrace($"status in vault is {vaultStatus}, status in db is {dbStatus}; updating db.");
+                            var newCert = new AnyCAPluginCertificate
+                            {
+                                CARequestID = trackingId,
+                                Certificate = certFromVault.Certificate,
+                                Status = vaultStatus,
+                                RevocationDate = certFromVault.RevocationTime
+                                // ProductID is not available via the API after the initial issuance.  we do not want to overwrite                            
+                            };
+                            if (blockingBuffer.TryAdd(newCert, 50, cancelToken))
+                            {
+                                logger.LogTrace($"successfully updated certificate {trackingId} in the database.");
+                            }
+                            else
+                            {
+                                logger.LogTrace($"adding to queue for writing was blocked.");
+                            }
                         }
                         else
                         {
-                            logger.LogTrace($"adding to queue for writing was blocked.");
+                            logger.LogTrace($"The status is unchanged and we are doing an incremental scan; no need to update db.");
                         }
                     }
-                    else
-                    {
-                        logger.LogTrace($"The status is unchanged and we are doing an incremental scan; no need to update db.");
-                    }
+                    count++;
                 }
-                Interlocked.Increment(ref count);
+                blockingBuffer.CompleteAdding();
+                logger.LogTrace($"Completed sync of {count} certificates.  It was {(fullSync ? "a full" : "an incremental")} sync and {changedCount} records were updated.");
             }
-            blockingBuffer.CompleteAdding();
-            logger.LogTrace($"Completed sync of {count} certificates.  It was {(fullSync ? "a full" : "an incremental")} sync and {changedCount} records were updated.");
-            logger.MethodExit();
-            Monitor.Exit(_caConfig);
+            finally
+            {
+                _semaphore.Release();
+                logger.MethodExit();
+            }            
         }
 
         /// <summary>

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -241,7 +241,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
             try
             {                
-                logger.LogTrace("getting all certificate serial numbers from vault");
+                logger.LogTrace($"getting all certificate serial numbers from vault from {_caConfig.Host} using namespace {_caConfig.Namespace} and mount-point {_caConfig.MountPoint}");
                 await hashiClient.GetAllCertSerialNumbers(certSerials, cancelToken);
             }
             catch (Exception ex)
@@ -329,7 +329,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                         logger.LogError($"Failed to add the cert to the database: {LogHandler.FlattenException(ex)}");
                         logger.LogTrace($"closing buffer and aborting sync");
                         blockingBuffer.CompleteAdding();
-                        break;
+                        throw;
                     }
                 }
                 else // the cert exists in the database; just update the status if necessary

--- a/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
+++ b/hashicorp-vault-cagateway/HashicorpVaultCAConnector.cs
@@ -240,6 +240,7 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
 
             var certSerials = new List<string>();
             var count = 0;
+            var changedCount = 0;
 
             try
             {
@@ -281,15 +282,16 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                     logger.LogTrace($"attempting to retreive status of cert with tracking id {trackingId} from the database");
                     dbStatus = await _certificateDataReader.GetStatusByRequestID(trackingId);
                 }
-                catch
+                catch(Exception ex)
                 {
+                    logger.LogTrace($"exception when retrieving cert from DB.  It could simply be missing, but logging for analysis: {ex.Message}");
                     logger.LogTrace($"tracking id {trackingId} was not found in the database.  it will be added.");
                 }
 
                 if (dbStatus == -1 || fullSync) // it's missing and needs added, or a full sync is requested
                 {
                     logger.LogTrace($"adding cert with serial {trackingId} to the database.  fullsync is {fullSync}, and the certificate {(dbStatus == -1 ? "does not yet exist" : "already exists")} in the database.");
-
+                    changedCount++;
                     var newCert = new AnyCAPluginCertificate
                     {
                         CARequestID = trackingId,
@@ -312,10 +314,13 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                 }
                 else // the cert exists in the database; just update the status if necessary
                 {
+                    logger.LogTrace($"certificate with id {trackingId} was found in the database, comparing status.");
                     var revoked = certFromVault.RevocationTime != null;
                     var vaultStatus = revoked ? (int)EndEntityStatus.REVOKED : (int)EndEntityStatus.GENERATED;
                     if (vaultStatus != dbStatus) // if there is a mismatch, we need to update
                     {
+                        changedCount++;
+                        logger.LogTrace($"status in vault is {vaultStatus}, status in db is {dbStatus}; updating db.");
                         var newCert = new AnyCAPluginCertificate
                         {
                             CARequestID = trackingId,
@@ -325,10 +330,13 @@ namespace Keyfactor.Extensions.CAPlugin.HashicorpVault
                             // ProductID is not available via the API after the initial issuance.  we do not want to overwrite                            
                         };
                     }
+                    else {
+                        logger.LogTrace($"The status is unchanged and we are doing an incremental scan; no need to update db.");
+                    }
                 }
                 count++;
             }
-            logger.LogTrace($"Completed sync of {count} certificates");
+            logger.LogTrace($"Completed sync of {count} certificates.  It was {(fullSync ? "a full" : "an incremental")} sync and {changedCount} records were updated.");
             logger.MethodExit();
         }
 


### PR DESCRIPTION
Updated to create a new instance of the vault client for each request to avoid the possibility of using a client configured for a different CA during multiple simultaneous CA synchronization jobs.